### PR TITLE
Forward requests through nginx

### DIFF
--- a/nginx_app/nginx.conf
+++ b/nginx_app/nginx.conf
@@ -39,6 +39,8 @@ http {
             gzip_min_length 512;
             expires $expires;
 
+            autoindex on;
+
             root /app/static;
             index index.html;
             include /etc/nginx/mime.types;

--- a/nginx_app/nginx.conf
+++ b/nginx_app/nginx.conf
@@ -46,5 +46,9 @@ http {
             include /etc/nginx/mime.types;
             try_files $uri $uri/ /index.html =404;
         }
+
+        location /api/v1 {
+           proxy_pass http://web_python:5000/api;
+        }
     }
 }

--- a/python_app/app.py
+++ b/python_app/app.py
@@ -83,7 +83,7 @@ def printFromDB():
 
     return "Success!"
 
-@app.route('/events', methods=['GET'])
+@app.route('/api/events', methods=['GET'])
 @cross_origin(origin='localhost',headers=['Content-Type','Authorization'])
 def get_all_events():
     events_collection = db['map_events']
@@ -100,7 +100,7 @@ def get_all_events():
     return jsonify({'map_events': output})
 
 # /<> defaults to strings without any slashes
-@app.route('/event/<event_name>', methods=['GET'])
+@app.route('/api/event/<event_name>', methods=['GET'])
 @cross_origin(origin='localhost',headers=['Content-Type','Authorization'])
 def get_one_event(event_name):
     events_collection = db['map_events']


### PR DESCRIPTION
https://stackoverflow.com/questions/46264954/connection-refused-while-connecting-to-upstream-when-using-nginx-as-reverse-prox

Can do localhost:5000/api/events or localhost:3000/api/v1/events, will forward through nginx at port 3000 to flask at port 5000.