### PR TITLE
Changed event dates to fit js date.parse() parameter reqs

### DIFF
--- a/python_app/events.py
+++ b/python_app/events.py
@@ -6,7 +6,7 @@ from flask_cors import CORS, cross_origin
 import pymongo
 import re
 import requests, urllib
-import time, datetime
+import time, datetime, dateutil.parser
 import event_caller
 
 Events = Blueprint('Events', __name__)
@@ -164,12 +164,13 @@ def process_event_info(event):
 def processed_time(old_time_str):
     # if not valid time string, return default value from dict.get()
     try:
-        # need to cut off time zone, not parseable in Python 2
-        time_obj = datetime.datetime.strptime(old_time_str[:19], '%Y-%m-%dT%H:%M:%S')
+        # use dateutil parser to get time zone
+        time_obj = dateutil.parser.parse(old_time_str)
     except ValueError:
         return old_time_str
     # Formatting according to date.parse() requirements
-    res_time_str = datetime.datetime.strftime(time_obj, '%a, %d %b %Y %H:%M:%S GMT-0800')
+    # time zone offset always off of GMT
+    res_time_str = datetime.datetime.strftime(time_obj, '%a, %d %b %Y %H:%M:%S GMT%z')
     return res_time_str
 
 # Get all UCLA-related Facebook events and add to database

--- a/python_app/events.py
+++ b/python_app/events.py
@@ -168,10 +168,7 @@ def processed_time(old_time_str):
         time_obj = datetime.datetime.strptime(old_time_str[:19], '%Y-%m-%dT%H:%M:%S')
     except ValueError:
         return old_time_str
-    # Formatting according to https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse
-    # %a, %d %b %Y %H:%M:%S GMT-0800 = "Fri, 01 Dec 2017 09:30:00 GMT-0800"
-    # '%-I:%M %p, %b %-d, %y' = "9:30 AM, Dec 1, 17"
-    # https://docs.python.org/2/library/datetime.html#strftime-strptime-behavior
+    # Formatting according to date.parse() requirements
     res_time_str = datetime.datetime.strftime(time_obj, '%a, %d %b %Y %H:%M:%S GMT-0800')
     return res_time_str
 

--- a/python_app/events.py
+++ b/python_app/events.py
@@ -168,7 +168,11 @@ def processed_time(old_time_str):
         time_obj = datetime.datetime.strptime(old_time_str[:19], '%Y-%m-%dT%H:%M:%S')
     except ValueError:
         return old_time_str
-    res_time_str = datetime.datetime.strftime(time_obj, '%-I:%M %p, %b %-d, %y')
+    # Formatting according to https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse
+    # %a, %d %b %Y %H:%M:%S GMT-0800 = "Fri, 01 Dec 2017 09:30:00 GMT-0800"
+    # '%-I:%M %p, %b %-d, %y' = "9:30 AM, Dec 1, 17"
+    # https://docs.python.org/2/library/datetime.html#strftime-strptime-behavior
+    res_time_str = datetime.datetime.strftime(time_obj, '%a, %d %b %Y %H:%M:%S GMT-0800')
     return res_time_str
 
 # Get all UCLA-related Facebook events and add to database

--- a/python_app/requirements.txt
+++ b/python_app/requirements.txt
@@ -3,3 +3,4 @@ flask_cors
 flask_oauth
 pymongo
 requests
+python-dateutil


### PR DESCRIPTION
Date.parse()
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse

https://docs.python.org/2/library/datetime.html#strftime-strptime-behavior
%a, %d %b %Y %H:%M:%S GMT-0800 = "Fri, 01 Dec 2017 09:30:00 GMT-0800"
%-I:%M %p, %b %-d, %y = "9:30 AM, Dec 1, 17"
