### PR TITLE
Added new package flask-compress which automatically gzips all files

### DIFF
--- a/src/mappening/__init__.py
+++ b/src/mappening/__init__.py
@@ -1,5 +1,6 @@
 from flask import Flask
 from flask_cors import CORS, cross_origin
+from flask_compress import Compress
 
 from mappening.api.events import events
 from mappening.api.locations import locations
@@ -8,6 +9,7 @@ from mappening.auth.auth import auth
 
 # Configure app and register blueprints
 app = Flask(__name__)
+Compress(app)
 
 app.register_blueprint(events, url_prefix='/api/v2/events')
 app.register_blueprint(locations, url_prefix='/api/v2/locations')

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,6 +1,7 @@
 flask
 flask_cors
 flask_oauth
+flask_compress
 flask_login
 pymongo
 requests


### PR DESCRIPTION
We should pull this in because it will allow us to compress all files served via the API, which will enable speedups on frontend. It's a minimal change. This works for me in testing when I run the backend and frontend in concert. Thanks.