### PR TITLE
Patched build error caused by missing werkzeug dependency

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -21,3 +21,4 @@ unidecode
 psycopg2
 Flask-SQLAlchemy
 eventbrite
+Werkzeug==0.16.1


### PR DESCRIPTION
Edited requirements.txt to add in missing werkzeug dependency. This should resolve any backend build errors regarding werkzeug until we remove it completely. 